### PR TITLE
Add publications to gene to phenotype associations (plus docs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,11 @@ test: download
 download:
 	$(RUN) ingest download
 
+data/genes_to_phenotype_with_publications.tsv: download
+	$(RUN) python scripts/gene_to_phenotype_publications.py
+
 .PHONY: run
-run: download
+run: data/genes_to_phenotype_with_publications.tsv
 	$(RUN) koza transform --source src/monarch_phenotype_profile_ingest/gene_to_disease_transform.yaml
 	$(RUN) koza transform --source src/monarch_phenotype_profile_ingest/gene_to_phenotype_transform.yaml
 	$(RUN) koza transform --source src/monarch_phenotype_profile_ingest/disease_to_phenotype_transform.yaml

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,210 @@
 {{ get_nodes_report() }}
 
 {{ get_edges_report() }}
+
+# Human Phenotype Ontology Annotations (HPOA)
+
+The [Human Phenotype Ontology](http://human-phenotype-ontology.org) group
+curates and assembles over 115,000 annotations to hereditary diseases
+using the HPO ontology. Here we create Biolink associations
+between diseases and phenotypic features, together with their evidence,
+and age of onset and frequency (if known).
+
+There are four HPOA ingests - 'disease-to-phenotype', 'disease-to-mode-of-inheritance', 'gene-to-disease' and 'gene-to-phenotype' - that parse out records from the [HPO Annotation File](http://purl.obolibrary.org/obo/hp/hpoa/phenotype.hpoa).
+
+## [Disease to Phenotype](#disease_to_phenotype)
+
+This ingest processes the tab-delimited [phenotype.hpoa](https://hpo-annotation-qc.readthedocs.io/en/latest/annotationFormat.html#phenotype-hpoa-format) file, filtered for rows with **Aspect == 'P'** (phenotypic anomalies).
+
+### Biolink Entities Captured
+
+* biolink:DiseaseToPhenotypicFeatureAssociation
+    * id (random uuid)
+    * subject (disease.id)
+    * predicate (has_phenotype)
+    * negated (True if 'qualifier' == "NOT")
+    * object (phenotypicFeature.id)
+    * publications (List[publication.id])
+    * has_evidence (List[evidence.id])
+    * sex_qualifier (female -> PATO:0000383, male -> PATO:0000384 or None)
+    * onset_qualifier (Onset.id)
+    * frequency_qualifier (See Frequencies section in hpoa.md)
+    * aggregating_knowledge_source (["infores:monarchinitiative"])
+    * primary_knowledge_source ("infores:hpo-annotations")
+
+### Example Source Data
+
+```json
+{
+  "database_id": "OMIM:117650",
+  "disease_name": "Cerebrocostomandibular syndrome",
+  "qualifier": "",
+  "hpo_id": "HP:0001249",
+  "reference": "OMIM:117650",
+  "evidence": "TAS",
+  "onset": "",
+  "frequency": "50%",
+  "sex": "",
+  "modifier": "",
+  "aspect": "P"
+}
+```
+
+### Example Transformed Data
+
+```json
+{
+  "id": "uuid:...",
+  "subject": "OMIM:117650",
+  "predicate": "biolink:has_phenotype",
+  "object": "HP:0001249",
+  "frequency_qualifier": 50.0,
+  "has_evidence": ["ECO:0000033"],
+  "primary_knowledge_source": "infores:hpo-annotations",
+  "aggregator_knowledge_source": ["infores:monarchinitiative"]
+}
+```
+
+## [Disease to Mode of Inheritance](#disease_modes_of_inheritance)
+
+This ingest processes the tab-delimited [phenotype.hpoa](https://hpo-annotation-qc.readthedocs.io/en/latest/annotationFormat.html#phenotype-hpoa-format) file, filtered for rows with **Aspect == 'I'** (inheritance).
+
+### Biolink Entities Captured
+
+* biolink:DiseaseOrPhenotypicFeatureToGeneticInheritanceAssociation
+    * id (random uuid)
+    * subject (disease.id)
+    * predicate (has_mode_of_inheritance)
+    * object (geneticInheritance.id)
+    * publications (List[publication.id])
+    * has_evidence (List[evidence.id])
+    * aggregating_knowledge_source (["infores:monarchinitiative"])
+    * primary_knowledge_source ("infores:hpo-annotations")
+
+### Example Source Data
+
+```json
+{
+  "database_id": "OMIM:300425",
+  "disease_name": "Autism susceptibility, X-linked 1",
+  "qualifier": "",
+  "hpo_id": "HP:0001417",
+  "reference": "OMIM:300425",
+  "evidence": "IEA",
+  "aspect": "I"
+}
+```
+
+### Example Transformed Data
+
+```json
+{
+  "id": "uuid:...",
+  "subject": "OMIM:300425",
+  "predicate": "biolink:has_mode_of_inheritance",
+  "object": "HP:0001417",
+  "has_evidence": ["ECO:0000501"],
+  "primary_knowledge_source": "infores:hpo-annotations",
+  "aggregator_knowledge_source": ["infores:monarchinitiative"]
+}
+```
+
+## [Gene to Disease](#gene_to_disease)
+
+This ingest replaces the direct OMIM ingest so that we share gene-to-disease associations 1:1 with HPO. It processes the tab-delimited [genes_to_disease.txt](http://purl.obolibrary.org/obo/hp/hpoa/genes_to_disease.txt) file.
+
+### Biolink Entities Captured
+
+* biolink:CorrelatedGeneToDiseaseAssociation or biolink:CausalGeneToDiseaseAssociation (depending on predicate)
+    * id (random uuid)
+    * subject (ncbi_gene_id)
+    * predicate (association_type)
+      * MENDELIAN: `biolink:causes`
+      * POLYGENIC: `biolink:contributes_to`
+      * UNKNOWN: `biolink:gene_associated_with_condition`
+    * object (disease_id)
+    * primary_knowledge_source (source)
+      * medgen: `infores:omim`
+      * orphanet: `infores:orphanet`
+    * aggregator_knowledge_source (["infores:monarchinitiative"])
+      * also for medgen: `infores:medgen`
+
+### Example Source Data
+
+```json
+{
+  "association_type": "MENDELIAN",
+  "disease_id": "OMIM:212050",
+  "gene_symbol": "CARD9",
+  "ncbi_gene_id": "NCBIGene:64170",
+  "source": "ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/mim2gene_medgen"
+}
+```
+
+### Example Transformed Data
+
+```json
+{
+  "id": "uuid:...",
+  "subject": "NCBIGene:64170",
+  "predicate": "biolink:causes",
+  "object": "OMIM:212050",
+  "primary_knowledge_source": "infores:omim",
+  "aggregator_knowledge_source": ["infores:monarchinitiative", "infores:medgen"]
+}
+```
+
+## [Gene to Phenotype](#gene_to_phenotype)
+
+This ingest processes the tab-delimited [genes_to_phenotype_with_publications.tsv](http://purl.obolibrary.org/obo/hp/hpoa/genes_to_phenotype.txt) file, which is generated by joining genes_to_phenotype.txt with phenotype.hpoa to add publication information.
+
+The publication data is pre-processed using the `scripts/gene_to_phenotype_publications.py` script, which performs a join between gene-to-phenotype associations and phenotype annotations in HPOA. The join is based on matching HPO terms, disease IDs, and frequency values. This enriches gene-to-phenotype associations with relevant publication references from the phenotype.hpoa file.
+
+During the transform process, publication identifiers are filtered to include only PMIDs (PubMed identifiers matching the pattern "PMID:\d+"). Non-PMID identifiers (such as OMIM references or other sources) are excluded from the final output.
+
+### Biolink Entities Captured
+
+* biolink:GeneToPhenotypicFeatureAssociation
+    * id (random uuid)
+    * subject (gene.id)
+    * predicate (has_phenotype)
+    * object (phenotypicFeature.id)
+    * publications (List[publication.id])
+    * frequency_qualifier (calculated from frequency data if available)
+    * in_taxon (NCBITaxon:9606)
+    * aggregating_knowledge_source (["infores:monarchinitiative"])
+    * primary_knowledge_source ("infores:hpo-annotations")
+
+### Example Source Data
+
+```json
+{
+  "ncbi_gene_id": "8192",
+  "gene_symbol": "CLPP",
+  "hpo_id": "HP:0000252",
+  "hpo_name": "Microcephaly",
+  "publications": "PMID:1234567;OMIM:614129",
+  "frequency": "3/10",
+  "disease_id": "OMIM:614129"
+}
+```
+
+### Example Transformed Data
+
+```json
+{
+  "id": "uuid:...",
+  "subject": "NCBIGene:8192",
+  "predicate": "biolink:has_phenotype",
+  "object": "HP:0000252",
+  "publications": ["PMID:1234567"],  // Note: Only PMID references are included, OMIM:614129 is filtered out
+  "frequency_qualifier": 30.0,
+  "in_taxon": "NCBITaxon:9606",
+  "primary_knowledge_source": "infores:hpo-annotations",
+  "aggregator_knowledge_source": ["infores:monarchinitiative"]
+}
+```
+
+## Citation
+
+Sebastian Köhler, Michael Gargano, Nicolas Matentzoglu, Leigh C Carmody, David Lewis-Smith, Nicole A Vasilevsky, Daniel Danis, Ganna Balagura, Gareth Baynam, Amy M Brower, Tiffany J Callahan, Christopher G Chute, Johanna L Est, Peter D Galer, Shiva Ganesan, Matthias Griese, Matthias Haimel, Julia Pazmandi, Marc Hanauer, Nomi L Harris, Michael J Hartnett, Maximilian Hastreiter, Fabian Hauck, Yongqun He, Tim Jeske, Hugh Kearney, Gerhard Kindle, Christoph Klein, Katrin Knoflach, Roland Krause, David Lagorce, Julie A McMurry, Jillian A Miller, Monica C Munoz-Torres, Rebecca L Peters, Christina K Rapp, Ana M Rath, Shahmir A Rind, Avi Z Rosenberg, Michael M Segal, Markus G Seidel, Damian Smedley, Tomer Talmy, Yarlalu Thomas, Samuel A Wiafe, Julie Xian, Zafer Yüksel, Ingo Helbig, Christopher J Mungall, Melissa A Haendel, Peter N Robinson, The Human Phenotype Ontology in 2021, Nucleic Acids Research, Volume 49, Issue D1, 8 January 2021, Pages D1207–D1217, https://doi.org/10.1093/nar/gkaa1043

--- a/docs/index.md
+++ b/docs/index.md
@@ -162,8 +162,6 @@ This ingest processes the tab-delimited [genes_to_phenotype_with_publications.ts
 
 The publication data is pre-processed using the `scripts/gene_to_phenotype_publications.py` script, which performs a join between gene-to-phenotype associations and phenotype annotations in HPOA. The join is based on matching HPO terms, disease IDs, and frequency values. This enriches gene-to-phenotype associations with relevant publication references from the phenotype.hpoa file.
 
-During the transform process, publication identifiers are filtered to include only PMIDs (PubMed identifiers matching the pattern "PMID:\d+"). Non-PMID identifiers (such as OMIM references or other sources) are excluded from the final output.
-
 ### Biolink Entities Captured
 
 * biolink:GeneToPhenotypicFeatureAssociation
@@ -199,7 +197,7 @@ During the transform process, publication identifiers are filtered to include on
   "subject": "NCBIGene:8192",
   "predicate": "biolink:has_phenotype",
   "object": "HP:0000252",
-  "publications": ["PMID:1234567"],  // Note: Only PMID references are included, OMIM:614129 is filtered out
+  "publications": ["PMID:1234567","OMIM:614129"],
   "frequency_qualifier": 30.0,
   "in_taxon": "NCBITaxon:9606",
   "primary_knowledge_source": "infores:hpo-annotations",

--- a/scripts/gene_to_phenotype_publications.py
+++ b/scripts/gene_to_phenotype_publications.py
@@ -1,0 +1,19 @@
+import duckdb
+
+db = duckdb.connect(":memory:", read_only=False)
+db.execute("""
+copy (
+with
+  hpoa as (select * from read_csv('data/phenotype.hpoa')),
+  g2p as (select * from read_csv('data/genes_to_phenotype.txt'))
+select g2p.*, array_to_string(list(hpoa.reference),';') as publications
+from g2p
+     left outer join hpoa on hpoa.hpo_id = g2p.hpo_id
+                 and g2p.disease_id = hpoa.database_id
+		 and hpoa.frequency = g2p.frequency
+group by all
+) to 'data/genes_to_phenotype_with_publications.tsv' (delimiter '\t', header true)
+""")
+
+
+     

--- a/scripts/gene_to_phenotype_publications.py
+++ b/scripts/gene_to_phenotype_publications.py
@@ -10,10 +10,7 @@ select g2p.*, array_to_string(list(hpoa.reference),';') as publications
 from g2p
      left outer join hpoa on hpoa.hpo_id = g2p.hpo_id
                  and g2p.disease_id = hpoa.database_id
-		 and hpoa.frequency = g2p.frequency
+		             and hpoa.frequency = g2p.frequency
 group by all
 ) to 'data/genes_to_phenotype_with_publications.tsv' (delimiter '\t', header true)
 """)
-
-
-     

--- a/src/monarch_phenotype_profile_ingest/gene_to_phenotype_transform.py
+++ b/src/monarch_phenotype_profile_ingest/gene_to_phenotype_transform.py
@@ -40,7 +40,6 @@ while (row := koza_app.get_row()) is not None:
 
 
     publications = row["publications"].split(";") if row["publications"] else []
-    pmids = [publication for publication in publications if re.match(r"^PMID:\d+$", publication)]
 
     association = GeneToPhenotypicFeatureAssociation(id="uuid:" + str(uuid.uuid1()),
                                                      subject=gene_id,
@@ -56,6 +55,6 @@ while (row := koza_app.get_row()) is not None:
                                                      has_count=frequency.has_count,
                                                      has_total=frequency.has_total,
                                                      disease_context_qualifier=dis_id,
-                                                     publications=pmids)
+                                                     publications=publications)
 
     koza_app.write(association)

--- a/src/monarch_phenotype_profile_ingest/gene_to_phenotype_transform.py
+++ b/src/monarch_phenotype_profile_ingest/gene_to_phenotype_transform.py
@@ -39,7 +39,7 @@ while (row := koza_app.get_row()) is not None:
         dis_id = mondo_map[dis_id]['subject_id']
 
 
-    publications = row["publications"].split(";") if row["publications"] else []
+    publications = [pub.strip() for pub in row["publications"].split(";")] if row["publications"] else []
 
     association = GeneToPhenotypicFeatureAssociation(id="uuid:" + str(uuid.uuid1()),
                                                      subject=gene_id,

--- a/src/monarch_phenotype_profile_ingest/gene_to_phenotype_transform.py
+++ b/src/monarch_phenotype_profile_ingest/gene_to_phenotype_transform.py
@@ -1,13 +1,16 @@
 # For generating UUIDs for associations
+import re
 import uuid
+
+from biolink_model.datamodel.pydanticmodel_v2 import (
+    AgentTypeEnum,
+    GeneToPhenotypicFeatureAssociation,
+    KnowledgeLevelEnum,
+)
 
 # Koza and biolink / pydantic imports
 from koza.cli_utils import get_koza_app
-from biolink_model.datamodel.pydanticmodel_v2 import (GeneToPhenotypicFeatureAssociation,
-                                                      KnowledgeLevelEnum,
-                                                      AgentTypeEnum)
-from phenotype_ingest_utils import phenotype_frequency_to_hpo_term, Frequency
-
+from phenotype_ingest_utils import Frequency, phenotype_frequency_to_hpo_term
 
 # TO DO: Once biolink is updated with the disease_context_qualifier slot we need to update the association we make
 # https://github.com/biolink/biolink-model/pull/1524
@@ -35,7 +38,9 @@ while (row := koza_app.get_row()) is not None:
     if dis_id in mondo_map:
         dis_id = mondo_map[dis_id]['subject_id']
 
-    # TO DO: we may want to incorporate the original disease id somehow?
+
+    publications = row["publications"].split(";") if row["publications"] else []
+    pmids = [publication for publication in publications if re.match(r"^PMID:\d+$", publication)]
 
     association = GeneToPhenotypicFeatureAssociation(id="uuid:" + str(uuid.uuid1()),
                                                      subject=gene_id,
@@ -50,6 +55,7 @@ while (row := koza_app.get_row()) is not None:
                                                      has_quotient=frequency.has_quotient,
                                                      has_count=frequency.has_count,
                                                      has_total=frequency.has_total,
-                                                     disease_context_qualifier=dis_id)
-    
+                                                     disease_context_qualifier=dis_id,
+                                                     publications=pmids)
+
     koza_app.write(association)

--- a/src/monarch_phenotype_profile_ingest/gene_to_phenotype_transform.yaml
+++ b/src/monarch_phenotype_profile_ingest/gene_to_phenotype_transform.yaml
@@ -6,9 +6,10 @@ transform_code: "src/monarch_phenotype_profile_ingest/gene_to_phenotype_transfor
 name: "hpoa_gene_to_phenotype" # This is the name of the koza app that is passed into the transform.py
 metadata: "src/monarch_phenotype_profile_ingest/metadata.yaml"
 
-# Main file for data ingest 
+# This file is produced by scripts/gene_to_phenotype_publications.py based on genes_to_phenotype.txt
+# and the publications from phenotype.hpoa given the same disease, phenotype and frequency columns
 files:
-  - 'data/genes_to_phenotype.txt'
+  - 'data/genes_to_phenotype_with_publications.tsv'
 
 depends_on:
   - 'src/monarch_phenotype_profile_ingest/mondo_sssom_config.yaml'
@@ -41,7 +42,8 @@ edge_properties:
   - 'has_percentage'
   - 'has_quotient'
   - 'disease_context_qualifier'
-    
+  - 'publications'
+
 transform_mode: 'flat'
 
 # We are using the mapping table functionality instead (may switch to this down the road...)

--- a/tests/test_gene_to_phenotype_transform.py
+++ b/tests/test_gene_to_phenotype_transform.py
@@ -47,7 +47,7 @@ def test_row():
         "gene_symbol": "CLPP",
         "hpo_id": "HP:0000252",
         "hpo_name": "Microcephaly",
-
+        "publications": "PMID:1234567;OMIM:614129",
         "frequency": "3/10",
         "disease_id": "OMIM:614129"
     }
@@ -63,7 +63,7 @@ def test_row_v2():
         "gene_symbol": "ZEB2",
         "hpo_id": "HP:0012429",
         "hpo_name": "Aplasia/Hypoplasia of the cerebral white matter",
-
+        "publications": "PMID:1234567",
         "frequency": "40.7%",
         "disease_id": "OMIM:235730"
     }
@@ -79,7 +79,7 @@ def test_row_v3():
         "gene_symbol": "AARS1",
         "hpo_id": "HP:0001284",
         "hpo_name": "Areflexia",
-
+        "publications": "PMID:1234567;PMID:2345678",
         "frequency": "-",
         "disease_id": "OMIM:613287"
     }
@@ -167,6 +167,7 @@ def test_hpoa_g2p_association(basic_hpoa):
     assert association.has_count == 3
     assert association.has_total == 10
     assert association.disease_context_qualifier == "OMIM:614129"
+    assert association.publications == ["PMID:1234567"]
 
 # Frequency data is in the form of percentage (i.e. 55% or 40.7% etc...)
 def test_hpoa_g2p_association_v2(basic_hpoa_v2):
@@ -188,6 +189,7 @@ def test_hpoa_g2p_association_v2(basic_hpoa_v2):
     assert association.has_count == None
     assert association.has_total == None
     assert association.disease_context_qualifier == "OMIM:235730"
+    assert association.publications == ["PMID:1234567"]
 
 # Frequency data is in the form of "-" (i.e. it does not exist)
 def test_hpoa_g2p_association_v3(basic_hpoa_v3):
@@ -207,3 +209,4 @@ def test_hpoa_g2p_association_v3(basic_hpoa_v3):
     assert association.primary_knowledge_source == "infores:hpo-annotations"
     assert association.disease_context_qualifier == "OMIM:613287"
     assert "infores:monarchinitiative" in association.aggregator_knowledge_source
+    assert association.publications == ["PMID:1234567", "PMID:2345678"]

--- a/tests/test_gene_to_phenotype_transform.py
+++ b/tests/test_gene_to_phenotype_transform.py
@@ -167,7 +167,7 @@ def test_hpoa_g2p_association(basic_hpoa):
     assert association.has_count == 3
     assert association.has_total == 10
     assert association.disease_context_qualifier == "OMIM:614129"
-    assert association.publications == ["PMID:1234567"]
+    assert association.publications == ["PMID:1234567","OMIM:614129"]
 
 # Frequency data is in the form of percentage (i.e. 55% or 40.7% etc...)
 def test_hpoa_g2p_association_v2(basic_hpoa_v2):


### PR DESCRIPTION
This adds a preprocessing step that joins phenotype.hpoa to the genes_to_phenotype.txt file using disease ID, hpo_id and frequency (the magic combination to get exactly the same number of rows after the join). 

I also use claude-cli to generate docs based on the old hpoa docs

- **add publications to g2p associations by joining to hpoa in a preprocessing step**
- **add/update docs**
