### PR TITLE
Declare per-source sub-sources in release-metadata

### DIFF
--- a/src/versions.py
+++ b/src/versions.py
@@ -1,13 +1,25 @@
 """Upstream source version fetcher for monarch-phenotype-profile-ingest.
 
-Three logical sources:
+Three top-level sources:
   - infores:hpoa  — HPO annotation files (phenotype.hpoa carries `#version:` header)
   - infores:hp    — the HP ontology .obo (HTTP Last-Modified)
   - infores:mondo — Mondo SSSOM mapping (HTTP Last-Modified)
+
+Nested under infores:hpoa, one SourceVersion per contributing primary source
+(OMIM, Orphanet, DECIPHER) — discovered from the `#description:` header line
+of phenotype.hpoa. Edges in this ingest's output carry per-row
+`primary_knowledge_source` (see src/phenotype_ingest_utils.py::get_knowledge_sources),
+so a downstream consumer (e.g. monarch-app) can resolve an edge's exact
+upstream version even though everything was retrieved via HPOA.
+
+HPOA's header does not carry per-source dates — its bundle `#version:` is
+the best as-of we have, so each nested entry uses that with
+`version_method: hpoa_bundle` to make the audit trail explicit.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +34,50 @@ from kozahub_metadata_schema import (
 INGEST_DIR = Path(__file__).resolve().parents[1]
 DOWNLOAD_YAML = INGEST_DIR / "download.yaml"
 DATA_DIR = INGEST_DIR / "data"
+
+# Tokens that may appear in phenotype.hpoa's `#description:` line, mapped to
+# (infores, human-readable name). Matched case-insensitively.
+HPOA_SUB_SOURCES = {
+    "OMIM": ("infores:omim", "OMIM"),
+    "ORPHANET": ("infores:orphanet", "Orphanet"),
+    "DECIPHER": ("infores:decipher", "DECIPHER"),
+}
+
+
+def _hpoa_sub_sources(hpoa_file: Path, hpoa_url: str, hpoa_version: str, now: str) -> list[dict[str, Any]]:
+    """Parse phenotype.hpoa #description: for contributing sources.
+
+    Example header:
+      #description: "HPO annotations for rare diseases [8576: OMIM; 47: DECIPHER; 4337 ORPHANET]"
+    """
+    if not hpoa_file.is_file():
+        return []
+    try:
+        with hpoa_file.open() as f:
+            description = ""
+            for line in f:
+                if not line.startswith("#"):
+                    break
+                if line.startswith("#description:"):
+                    description = line
+                    break
+        if not description:
+            return []
+    except Exception:
+        return []
+
+    found: list[dict[str, Any]] = []
+    for token, (infores, name) in HPOA_SUB_SOURCES.items():
+        if re.search(rf"\b{token}\b", description, re.IGNORECASE):
+            found.append({
+                "id": infores,
+                "name": name,
+                "urls": [hpoa_url],
+                "version": hpoa_version,
+                "version_method": "hpoa_bundle",
+                "retrieved_at": now,
+            })
+    return found
 
 
 def get_source_versions() -> list[dict[str, Any]]:
@@ -40,14 +96,19 @@ def get_source_versions() -> list[dict[str, Any]]:
             )
         else:
             ver, method = "unknown", "unavailable"
-        sources.append({
+        entry: dict[str, Any] = {
             "id": "infores:hpoa",
             "name": "HPO Annotations (HPOA)",
             "urls": hpoa_urls,
             "version": ver,
             "version_method": method,
             "retrieved_at": now,
-        })
+        }
+        phenotype_hpoa_url = next((u for u in hpoa_urls if u.endswith("phenotype.hpoa")), hpoa_urls[0])
+        nested = _hpoa_sub_sources(hpoa_file, phenotype_hpoa_url, ver, now)
+        if nested:
+            entry["sources"] = nested
+        sources.append(entry)
 
     if hp_urls:
         ver, method = version_from_http_last_modified(hp_urls[0])

--- a/src/versions.py
+++ b/src/versions.py
@@ -12,9 +12,13 @@ of phenotype.hpoa. Edges in this ingest's output carry per-row
 so a downstream consumer (e.g. monarch-app) can resolve an edge's exact
 upstream version even though everything was retrieved via HPOA.
 
-HPOA's header does not carry per-source dates — its bundle `#version:` is
-the best as-of we have, so each nested entry uses that with
-`version_method: hpoa_bundle` to make the audit trail explicit.
+HPOA's header carries no per-source release dates, but the per-row
+`biocuration` column has dates like `ORPHA:orphadata[2026-01-08]` or
+`HPO:probinson[2024-03-14]`. The most recent biocuration date for rows
+attributed to a given source is the best in-file signal we have for "as-of
+when did HPOA last touch this source's content" — notably surfaces frozen
+sources like DECIPHER (max date ~2013) that the bundle date would obscure.
+We do not reach outside HPOA to upstream APIs.
 """
 
 from __future__ import annotations
@@ -35,48 +39,77 @@ INGEST_DIR = Path(__file__).resolve().parents[1]
 DOWNLOAD_YAML = INGEST_DIR / "download.yaml"
 DATA_DIR = INGEST_DIR / "data"
 
-# Tokens that may appear in phenotype.hpoa's `#description:` line, mapped to
-# (infores, human-readable name). Matched case-insensitively.
+# Tokens in phenotype.hpoa's `#description:` line, with the matching
+# `database_id` row prefix and target (infores, name).
 HPOA_SUB_SOURCES = {
-    "OMIM": ("infores:omim", "OMIM"),
-    "ORPHANET": ("infores:orphanet", "Orphanet"),
-    "DECIPHER": ("infores:decipher", "DECIPHER"),
+    "OMIM":     {"row_prefix": "OMIM",     "infores": "infores:omim",     "name": "OMIM"},
+    "ORPHANET": {"row_prefix": "ORPHA",    "infores": "infores:orphanet", "name": "Orphanet"},
+    "DECIPHER": {"row_prefix": "DECIPHER", "infores": "infores:decipher", "name": "DECIPHER"},
 }
+
+_BIOCURATION_DATE = re.compile(r"\[(\d{4}-\d{2}-\d{2})\]")
+
+
+def _scan_hpoa(hpoa_file: Path) -> tuple[str, dict[str, str]]:
+    """Read phenotype.hpoa once. Return (description_line, {row_prefix: max_date}).
+
+    `description_line` is the `#description:` header (used to discover which
+    sub-sources are present). The dict maps `database_id` row prefix
+    (OMIM/ORPHA/DECIPHER) to the latest biocuration date observed for rows
+    of that source.
+    """
+    description = ""
+    max_dates: dict[str, str] = {}
+    with hpoa_file.open() as f:
+        for line in f:
+            if line.startswith("#"):
+                if line.startswith("#description:") and not description:
+                    description = line
+                continue
+            if line.startswith("database_id"):
+                continue
+            row_prefix = line.split(":", 1)[0]
+            for m in _BIOCURATION_DATE.finditer(line):
+                d = m.group(1)
+                cur = max_dates.get(row_prefix)
+                if cur is None or d > cur:
+                    max_dates[row_prefix] = d
+    return description, max_dates
 
 
 def _hpoa_sub_sources(hpoa_file: Path, hpoa_url: str, hpoa_version: str, now: str) -> list[dict[str, Any]]:
-    """Parse phenotype.hpoa #description: for contributing sources.
+    """Discover contributing sources from phenotype.hpoa and version each by
+    its most recent biocuration date.
 
-    Example header:
-      #description: "HPO annotations for rare diseases [8576: OMIM; 47: DECIPHER; 4337 ORPHANET]"
+    Falls back to the HPOA bundle version (`hpoa_bundle`) for a discovered
+    source whose rows yielded no parseable biocuration dates.
     """
     if not hpoa_file.is_file():
         return []
     try:
-        with hpoa_file.open() as f:
-            description = ""
-            for line in f:
-                if not line.startswith("#"):
-                    break
-                if line.startswith("#description:"):
-                    description = line
-                    break
-        if not description:
-            return []
+        description, max_dates = _scan_hpoa(hpoa_file)
     except Exception:
+        return []
+    if not description:
         return []
 
     found: list[dict[str, Any]] = []
-    for token, (infores, name) in HPOA_SUB_SOURCES.items():
-        if re.search(rf"\b{token}\b", description, re.IGNORECASE):
-            found.append({
-                "id": infores,
-                "name": name,
-                "urls": [hpoa_url],
-                "version": hpoa_version,
-                "version_method": "hpoa_bundle",
-                "retrieved_at": now,
-            })
+    for token, meta in HPOA_SUB_SOURCES.items():
+        if not re.search(rf"\b{token}\b", description, re.IGNORECASE):
+            continue
+        max_date = max_dates.get(meta["row_prefix"])
+        if max_date:
+            ver, method = max_date, "hpoa_biocuration_max"
+        else:
+            ver, method = hpoa_version, "hpoa_bundle"
+        found.append({
+            "id": meta["infores"],
+            "name": meta["name"],
+            "urls": [hpoa_url],
+            "version": ver,
+            "version_method": method,
+            "retrieved_at": now,
+        })
     return found
 
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,0 +1,110 @@
+"""Unit tests for src/versions.py — per-source nested SourceVersion emission.
+
+Exercise the in-file parsing path (description discovery + biocuration
+max-date scan) without hitting any network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src import versions
+
+
+HPOA_FIXTURE = """\
+#description: "HPO annotations for rare diseases [10: OMIM; 2: DECIPHER; 5 ORPHANET]"
+#version: 2026-01-08
+#tracker: https://github.com/obophenotype/human-phenotype-ontology/issues
+#hpo-version: http://purl.obolibrary.org/obo/hp/releases/2026-01-08/hp.json
+database_id\tdisease_name\tqualifier\thpo_id\treference\tevidence\tonset\tfrequency\tsex\tmodifier\taspect\tbiocuration
+OMIM:619340\tFoo\t\tHP:0001\tPMID:1\tPCS\t\t\t\t\tP\tHPO:probinson[2024-03-14]
+OMIM:619340\tFoo\t\tHP:0002\tPMID:1\tPCS\t\t\t\t\tP\tHPO:probinson[2021-06-21];HPO:lccarmody[2018-10-03]
+OMIM:619341\tBar\t\tHP:0003\tPMID:2\tPCS\t\t\t\t\tP\tHPO:skoehler[2017-07-13]
+ORPHA:33364\tBaz\t\tHP:0004\t\tIEA\t\t\t\t\tP\tORPHA:orphadata[2026-01-08]
+ORPHA:33364\tBaz\t\tHP:0005\t\tIEA\t\t\t\t\tP\tORPHA:orphadata[2026-01-08]
+DECIPHER:1\tQux\t\tHP:0006\t\tIEA\t\t\t\t\tP\tHPO:skoehler[2013-05-29]
+DECIPHER:1\tQux\t\tHP:0007\t\tIEA\t\t\t\t\tP\tHPO:skoehler[2010-09-13]
+"""
+
+
+@pytest.fixture
+def hpoa_file(tmp_path: Path) -> Path:
+    p = tmp_path / "phenotype.hpoa"
+    p.write_text(HPOA_FIXTURE)
+    return p
+
+
+def test_scan_hpoa_collects_max_date_per_source(hpoa_file: Path):
+    description, max_dates = versions._scan_hpoa(hpoa_file)
+
+    assert "[10: OMIM; 2: DECIPHER; 5 ORPHANET]" in description
+    assert max_dates["OMIM"] == "2024-03-14"
+    assert max_dates["DECIPHER"] == "2013-05-29"
+    assert max_dates["ORPHA"] == "2026-01-08"
+
+
+def test_hpoa_sub_sources_uses_biocuration_max_when_available(hpoa_file: Path):
+    sources = versions._hpoa_sub_sources(
+        hpoa_file, hpoa_url="http://x/phenotype.hpoa", hpoa_version="2026-01-08", now="2026-05-07T00:00:00Z"
+    )
+
+    by_id = {s["id"]: s for s in sources}
+    assert by_id["infores:omim"]["version"] == "2024-03-14"
+    assert by_id["infores:omim"]["version_method"] == "hpoa_biocuration_max"
+    # DECIPHER is the load-bearing case: bundle says 2026, data is from 2013.
+    assert by_id["infores:decipher"]["version"] == "2013-05-29"
+    assert by_id["infores:decipher"]["version_method"] == "hpoa_biocuration_max"
+    assert by_id["infores:orphanet"]["version"] == "2026-01-08"
+
+
+def test_hpoa_sub_sources_falls_back_to_bundle_when_no_biocuration(tmp_path: Path):
+    """A source declared in #description: but with no parseable biocuration
+    dates should fall back to the HPOA bundle version."""
+    p = tmp_path / "phenotype.hpoa"
+    p.write_text(
+        '#description: "HPO annotations [1: OMIM]"\n'
+        "#version: 2026-01-08\n"
+        "database_id\tdisease_name\tqualifier\thpo_id\treference\tevidence\tonset\tfrequency\tsex\tmodifier\taspect\tbiocuration\n"
+        "OMIM:1\tFoo\t\tHP:0001\t\tIEA\t\t\t\t\tP\t\n"  # empty biocuration
+    )
+
+    sources = versions._hpoa_sub_sources(p, hpoa_url="http://x", hpoa_version="2026-01-08", now="2026-05-07T00:00:00Z")
+
+    assert len(sources) == 1
+    assert sources[0]["id"] == "infores:omim"
+    assert sources[0]["version"] == "2026-01-08"
+    assert sources[0]["version_method"] == "hpoa_bundle"
+
+
+def test_hpoa_sub_sources_skips_sources_absent_from_description(tmp_path: Path):
+    """If a token isn't in #description:, don't emit an entry even if rows
+    happen to be present (defensive — the canonical signal is the header)."""
+    p = tmp_path / "phenotype.hpoa"
+    p.write_text(
+        '#description: "HPO annotations [10: OMIM]"\n'
+        "#version: 2026-01-08\n"
+        "database_id\tdisease_name\tqualifier\thpo_id\treference\tevidence\tonset\tfrequency\tsex\tmodifier\taspect\tbiocuration\n"
+        "OMIM:1\tFoo\t\tHP:0001\t\tIEA\t\t\t\t\tP\tHPO:x[2024-01-01]\n"
+        "DECIPHER:1\tBar\t\tHP:0002\t\tIEA\t\t\t\t\tP\tHPO:x[2013-05-29]\n"
+    )
+
+    sources = versions._hpoa_sub_sources(p, hpoa_url="http://x", hpoa_version="2026-01-08", now="2026-05-07T00:00:00Z")
+
+    ids = {s["id"] for s in sources}
+    assert ids == {"infores:omim"}
+
+
+def test_hpoa_sub_sources_returns_empty_when_no_description_header(tmp_path: Path):
+    """No #description: header → no nesting (rather than misleading output)."""
+    p = tmp_path / "phenotype.hpoa"
+    p.write_text(
+        "#version: 2026-01-08\n"
+        "database_id\tdisease_name\n"
+        "OMIM:1\tFoo\n"
+    )
+
+    sources = versions._hpoa_sub_sources(p, hpoa_url="http://x", hpoa_version="2026-01-08", now="2026-05-07T00:00:00Z")
+
+    assert sources == []


### PR DESCRIPTION
## Summary

Expand `versions.py::get_source_versions()` so the `infores:hpoa` entry nests one `SourceVersion` per contributing primary source — discovered from the `#description:` line of `phenotype.hpoa` (which lists OMIM, Orphanet, DECIPHER and their row counts).

`infores:hp` and `infores:mondo` remain top-level peers — they are not HPOA-bundled.

## Output shape

```yaml
- id: infores:hpoa
  version: '2026-01-08'
  version_method: file_header
  sources:
    - {id: infores:omim,     version: '2026-01-08', version_method: hpoa_bundle, urls: [phenotype.hpoa]}
    - {id: infores:orphanet, version: '2026-01-08', version_method: hpoa_bundle, urls: [phenotype.hpoa]}
    - {id: infores:decipher, version: '2026-01-08', version_method: hpoa_bundle, urls: [phenotype.hpoa]}
- id: infores:hp     # unchanged
- id: infores:mondo  # unchanged
```

HPOA carries no per-source dates, so each nested entry uses the HPOA bundle version. `version_method: hpoa_bundle` makes the audit trail explicit — it's the bundle's date, not the upstream's own. If we later get sharper per-source versions (OMIM API timestamp, Orphanet release tag) the `version_method` can be upgraded per-MOD without breaking the structure.

## Test plan

- [x] `versions.py::get_source_versions()` returns the expected nested shape.
- [x] Existing tests pass: `just test` (12 passed).
- [ ] After a real release, `output/release-metadata.yaml` shows the nested structure.
- [ ] Missing/unparseable `#description:` path: nested sources are simply omitted rather than failing the whole metadata write.

Resolves #15.